### PR TITLE
Handle lack of SIGPOLL on FreeBSD.

### DIFF
--- a/unix-signals/private/unix-signals-extension.c
+++ b/unix-signals/private/unix-signals-extension.c
@@ -109,7 +109,7 @@ Scheme_Object *prim_get_signal_names(int argc, Scheme_Object **argv) {
 
   /* Not POSIX.1-1990, but SUSv2 and POSIX.1-2001 */
   ADD_SIGNAL_NAME(SIGBUS);
-#if !defined(__APPLE__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__)
   ADD_SIGNAL_NAME(SIGPOLL);
 #endif
   ADD_SIGNAL_NAME(SIGPROF);


### PR DESCRIPTION
With this change, unix-signals builds cleanly on FreeBSD 12.1. (I didn't check older versions of FreeBSD.)